### PR TITLE
fix(selected race): use entrants instead of finishers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "racebot-stats",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "homepage": "https://fleury14.github.io/racebot-stats",
   "dependencies": {

--- a/src/components/selected-race/SelectedRace.js
+++ b/src/components/selected-race/SelectedRace.js
@@ -49,6 +49,16 @@ class SelectedRace extends Component {
   render() {
     const { raceData, loading } = this.state;
     const dataCreated = raceData ? new Date(raceData.details.created) : null;
+    let finishers = null;
+    if (raceData && raceData.details && raceData.details.entrants) {
+      finishers = raceData.details.entrants.sort((a, b) => {
+        if (a.status === 'Forfeited' && b.status === 'Forfeited') return 0;
+        if (a.status === 'Forfeited' && b.status !== 'Forfeited') return 1;
+        if (a.status !== 'Forfeited' && b.status === 'Forfeited') return -1;
+        return a.placement - b.placement
+      });
+    }
+    console.log('racedata', raceData, 'finishers', finishers);
     return (
       <div className="race-stats-container">
         <Navbar />
@@ -97,7 +107,7 @@ class SelectedRace extends Component {
               </Container>
             </div>
           )}
-          {raceData && raceData.details && raceData.details.finishers && raceData.details.finishers.length > 0 && (
+          {finishers && (
             <div className="race-stats-finisher-bubble">
               <Table striped borderless>
                 <thead>
@@ -108,7 +118,7 @@ class SelectedRace extends Component {
                   </tr>
                 </thead>
                 <tbody>
-                  {raceData.details.finishers.map(finisher => {
+                  {finishers.map(finisher => {
                     return (
                       <tr key={finisher.id}>
                         <th>{finisher.placement}</th>

--- a/src/components/twov2-stats/Twov2Stats.js
+++ b/src/components/twov2-stats/Twov2Stats.js
@@ -5,9 +5,11 @@ import './Twov2Stats.scss';
 
 const Twov2Stats = (props) => {
   const { data, currentRacer } = props;
+  console.log('data', data)
   return (
     <div className="pairs-container">
       <h1 className="text-center text-uppercase">Partner Stats (2v2)</h1>
+      <h4 className="text-center text-uppercase">(Races entered) Record</h4>
       {data.map((team, index) => {
         return (
           <div key={index} className="d-flex">
@@ -15,7 +17,7 @@ const Twov2Stats = (props) => {
               <h3>{team.racer1Name === currentRacer ? team.racer2Name : team.racer1Name}:</h3>
             </div>
             <div className="w-50 pr-3 text-left">
-              <h4>{team.wins} - {team.losses}</h4>
+              <h4>({team.races_entered.length}) {team.wins} - {team.losses}</h4>
             </div>
           </div>
         );

--- a/src/components/twov2-stats/Twov2Stats.js
+++ b/src/components/twov2-stats/Twov2Stats.js
@@ -5,7 +5,6 @@ import './Twov2Stats.scss';
 
 const Twov2Stats = (props) => {
   const { data, currentRacer } = props;
-  console.log('data', data)
   return (
     <div className="pairs-container">
       <h1 className="text-center text-uppercase">Partner Stats (2v2)</h1>


### PR DESCRIPTION
Finishing time uses `entrants` instead of the `finishers` which is inconsistent and will soon be deprecated.

Also took CaitSith1's suggestion of displaying the number of times you've partnered with someone in the 2v2 stats.