### PR TITLE
Neerm api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "racebot-stats",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2990,7 +2990,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3008,11 +3009,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3025,15 +3028,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3136,7 +3142,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3146,6 +3153,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3158,17 +3166,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3185,6 +3196,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3257,7 +3269,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3267,6 +3280,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3342,7 +3356,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3372,6 +3387,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3389,6 +3405,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3427,11 +3444,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6587,7 +6606,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6605,11 +6625,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6622,15 +6644,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6733,7 +6758,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6743,6 +6769,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6755,17 +6782,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6782,6 +6812,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6854,7 +6885,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6864,6 +6896,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6939,7 +6972,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6969,6 +7003,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6986,6 +7021,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7024,11 +7060,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "racebot-stats",
   "version": "0.2.2",
   "private": true,
-  "homepage": "https://fleury14.github.io/racebot-stats",
+  "homepage": "http://adaptable-rabbit.surge.sh",
   "dependencies": {
     "axios": "^0.18.0",
     "bootstrap": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "racebot-stats",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "homepage": "http://adaptable-rabbit.surge.sh",
   "dependencies": {

--- a/src/components/flag-stats/FlagStats.js
+++ b/src/components/flag-stats/FlagStats.js
@@ -11,7 +11,8 @@ const FlagStats = (props) => {
   return (
     <ReduxMainData>
       {(reduxData) => {
-        const data = parseFlagStats(reduxData.botData);
+        console.log('redux', reduxData);
+        const data = parseFlagStats(reduxData.botData ? reduxData.botData.items : null);
         const loading = reduxData.loading;
         return (
           <div>

--- a/src/components/player-directory/PlayerDirectory.js
+++ b/src/components/player-directory/PlayerDirectory.js
@@ -79,8 +79,7 @@ class PlayerDirectory extends Component {
     return (
       <ReduxRacerData>
         {(reduxData) => {
-          
-          const { racerData } = reduxData;
+          const racerData =  reduxData.racerData ? reduxData.racerData.items : null;
           const { startIndex, endIndex } = this.state;
           let sortedData = racerData ? this.sortPlayers(racerData) : null;
           let paginatedData = racerData ? sortedData.filter((race, index) => index >= startIndex && index <= endIndex) : null;

--- a/src/components/redux-data/ReduxSingleRacerData.js
+++ b/src/components/redux-data/ReduxSingleRacerData.js
@@ -30,7 +30,7 @@ class ReduxSingleRacerData extends Component {
   }
 
   componentDidUpdate() {
-
+    console.log('prizzops', this.props)
     // if its not loading, then we need to check a few things
     // is there no racename prop? (return)
     // we have no data in state or is there a racename prop but it doesnt match our race data (grab new data)
@@ -38,7 +38,7 @@ class ReduxSingleRacerData extends Component {
     if (!this.props.racerName) {
       
       return
-    } else if ((!this.state.racerData || (this.props.raceName && this.props.raceName !== this.props.racerData.name)) && !this.state.loading) {
+    } else if ((!this.props.racerData) || ((!this.state.racerData || (this.props.raceName && this.props.raceName !== this.props.racerData.name)) && !this.state.loading)) {
       this.props.getData(this.props.racerName);
       this.setState({ loading: true });
     } else if ((this.props.racerName && this.props.racerName === this.props.racerData.name && (!this.state.racerData || this.props.racerData.name === this.state.racerData.name)) && (!this.state.racerData || this.state.racerData.name !== this.props.racerName)) {

--- a/src/components/redux-data/ReduxSingleRacerData.js
+++ b/src/components/redux-data/ReduxSingleRacerData.js
@@ -30,7 +30,6 @@ class ReduxSingleRacerData extends Component {
   }
 
   componentDidUpdate() {
-    console.log('prizzops', this.props)
     // if its not loading, then we need to check a few things
     // is there no racename prop? (return)
     // we have no data in state or is there a racename prop but it doesnt match our race data (grab new data)

--- a/src/components/selected-race/SelectedRace.js
+++ b/src/components/selected-race/SelectedRace.js
@@ -22,7 +22,6 @@ const SelectedRace = (props) => {
             return a.placement - b.placement
           });
         }
-        console.log('racedata', raceData, 'finishers', finishers);
         return (
           <div className="race-stats-container">
             <Navbar />

--- a/src/components/win-loss/WinLoss.js
+++ b/src/components/win-loss/WinLoss.js
@@ -15,7 +15,6 @@ class WinLoss extends Component {
   componentDidMount() {
     const { data, selectedPlayer } = this.props;
     const dataResult = ParseWinLoss(data.items || data);
-    console.log('stats', dataResult);
     if (selectedPlayer) {
       this.setState({ playerWinLoss: dataResult.find(racer => racer.name.toLowerCase() === selectedPlayer.toLowerCase()) });
     }

--- a/src/helpers/GetCurrentRaces.js
+++ b/src/helpers/GetCurrentRaces.js
@@ -2,7 +2,7 @@
 const GetCurrentRaces = (data) => {
   if (!data) return [];
   const runningString = 'Running';
-  const currentRaces = data.filter(race => race.details.status === runningString);
+  const currentRaces = data.filter(race => race.details.status === runningString && race.details.guild && race.details.guild.name === 'Free Enterprise Workshop');
   return currentRaces;
 }
 

--- a/src/helpers/GetRecentlyCompleteRaces.js
+++ b/src/helpers/GetRecentlyCompleteRaces.js
@@ -2,7 +2,7 @@
 const GetRecentlyCompleteRaces = (data) => {
   if (!data) return [];
   const completedString = 'Completed';
-  let filteredData = data.filter(race => race.details.status && race.details.finishTime && race.details.status === completedString);
+  let filteredData = data.filter(race => race.details.status && race.details.finishTime && race.details.status === completedString && race.details.guild && race.details.guild.name === 'Free Enterprise Workshop');
   filteredData.sort((race1, race2) => {
     const finished1 = new Date(race1.details.finishTime);
     const finished2 = new Date(race2.details.finishTime);

--- a/src/helpers/Parse2v2.js
+++ b/src/helpers/Parse2v2.js
@@ -5,7 +5,7 @@ const parse2v2Data = (data) => {
   const twov2String = '2v2';
 
   // loop through each race
-  for (let race of data) {
+  for (let race of data.items) {
     // skip over races that arent complete and arent 2v2's
     // if (race.details.mode !== twov2String) console.log('not finished');
     if (race.details.status !== completedString || (race.details.mode !== twov2String && race.key.indexOf('2v2') && race.details.type.indexOf('2v2') < 0)) {

--- a/src/redux/actions/BotActions.js
+++ b/src/redux/actions/BotActions.js
@@ -46,7 +46,6 @@ export const getRacerData = (racer) => {
         // flip history if exists
         // have to have two conditionals for different data formatitting
         // new ver
-        console.log('resp', response);
         // if (Array.isArray(response.data)) {
         //   if (response.data.race_details.races_completed) {
         //     response.data.race_details.races_completed.reverse();

--- a/src/redux/actions/BotActions.js
+++ b/src/redux/actions/BotActions.js
@@ -22,7 +22,7 @@ const loadError = error => ({
 
 const apiUrl = process.env.REACT_APP_RACEBOT_API_URL;
 const apiKey = process.env.REACT_APP_RACEBOT_APIKEY;
-const apiHeader = 'x-api-key';
+const apiHeader = 'apikey';
 
 export const getBotData = () => {
   return (dispatch) => {

--- a/src/redux/actions/BotActions.js
+++ b/src/redux/actions/BotActions.js
@@ -46,17 +46,18 @@ export const getRacerData = (racer) => {
         // flip history if exists
         // have to have two conditionals for different data formatitting
         // new ver
-        if (Array.isArray(response.data)) {
-          if (response.data[0].race_details.races_completed) {
-            response.data[0].race_details.races_completed.reverse();
-          }
-        }
-        // oldver
-        // if (response.data.race_details.races_completed) {
-        //   response.data.race_details.races_completed.reverse();
+        console.log('resp', response);
+        // if (Array.isArray(response.data)) {
+        //   if (response.data.race_details.races_completed) {
+        //     response.data.race_details.races_completed.reverse();
+        //   }
         // }
-        response.data[0].dataTime = Date.now();
-        dispatch(loadFinish(response.data[0], DATA_DONE_LOADING_RACER));
+        // oldver
+        if (response.data.race_details.races_completed) {
+          response.data.race_details.races_completed.reverse();
+        }
+        response.data.dataTime = Date.now();
+        dispatch(loadFinish(response.data, DATA_DONE_LOADING_RACER));
       })
       .catch(err => {
         console.log('error', err);

--- a/src/router/AppRouter.js
+++ b/src/router/AppRouter.js
@@ -6,7 +6,7 @@ import { Main, RacerStats, SelectedRace, RaceDirectory, PlayerDirectory, ErrorCo
 class AppRouter extends Component {
   render() {
     return (
-      <Router basename="/racebot-stats">
+      <Router basename="/">
         <Switch>
           <Route path="/" exact component={Main} />
           <Route path="/flag-stats" exact component={FlagStats} />


### PR DESCRIPTION
Adjustments for using the new api hosted by neerrm. It uses the data format that the old supremacy API uses (aka theres now an `items` property) so that required adjusting. Also, since the new API is HTTP and not HTTPS, I have to deploy via surge. As a result, adjustments to the homepages and basename had to be made.

Finally, per request, only races from the Free Enterprise Workshop are displayed in current races.