### PR TITLE
Wager touchup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "racebot-stats",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "homepage": "http://adaptable-rabbit.surge.sh",
   "dependencies": {

--- a/src/helpers/ParseWagers.js
+++ b/src/helpers/ParseWagers.js
@@ -1,4 +1,9 @@
 const ParseWagers = (races) => {
+  races.items.sort((a, b) => {
+    const date1 = new Date(a.details.created);
+    const date2 = new Date(b.details.created);
+    return date1.getTime() - date2.getTime();
+  })
   const racesWithWagers = [];
   races.items.forEach(race => {
     if (race.details && race.details.entrants) {
@@ -30,9 +35,12 @@ const ParseWagers = (races) => {
     });
     currentRace.details.entrants.forEach(entrant => {
       let winnings = 0;
-      let currentBettor = allBetters.find(bettor => bettor.name === entrant.name);
+      let currentBettor = allBetters.find(bettor => bettor.id === entrant.id);
       if (currentBettor) {
         currentBettor.wagerTotal += entrant.wager;
+        if (entrant.name !== currentBettor.name) {
+          currentBettor.name = entrant.name
+        }
       } else {
         allBetters.push({
           name: entrant.name,
@@ -40,7 +48,7 @@ const ParseWagers = (races) => {
           wagerTotal: entrant.wager,
           id: entrant.id,
         });
-        currentBettor = allBetters.find(bettor => bettor.name === entrant.name);
+        currentBettor = allBetters.find(bettor => bettor.id === entrant.id);
       }
       switch (entrant.placement) {
         case 1:


### PR DESCRIPTION
Minor fix:

parseWagers searches for bettors by id so name changes won't register as two different people anymore. Also sorted races by date so if a user name changes, the name will update as well. Unfortunately, this means that if someone changes their name, the wager name will only update if they wager on another race.